### PR TITLE
Sam mobile responsiveness

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 const Navbar: React.FC = () => {
   return (
-    <div className="w-screen h-24 flex justify-start gap-2 items-center p-5 bg-transparent absolute top-0 left-0 z-100 shadow-xl" style={{backgroundColor: '#233039'}}>
+    <div className="w-screen h-24 flex justify-start gap-2 items-center p-5 bg-transparent sm:absolute top-0 left-0 z-100 shadow-xl" style={{backgroundColor: '#233039'}}>
       <Link to="/" className="text-5xl font-mono font-extrabold mr-5">MUTAGEN</Link>
       <ul className="flex space-x-5 font-mono text-xl">
         {/* <li><Link to="/characters">Characters</Link></li> */}

--- a/src/components/strikey/ModifierContainer.tsx
+++ b/src/components/strikey/ModifierContainer.tsx
@@ -11,7 +11,7 @@ interface ModifierContainerProps {
 
 const ModifierContainer: React.FC<ModifierContainerProps> = ({ type, items, quickAdd, addModifier }) => (
   
-  <div className="htmlForm-group bg-teal-900 p-5 flex flex-col space-y-5 rounded-md w-1/2">
+  <div className="htmlForm-group bg-teal-900 p-5 flex flex-col space-y-5 rounded-md mb-2 sm:mb-0 sm:w-1/2">
     <label className="text-2xl font-bold" htmlFor={type === 'penalty' ? 'penalties' : 'bonuses'}>{type === 'penalty' ? 'Penalties' : 'Bonuses'}</label>
     <div className="flex flex-col justify-center items-center space-y-3">
       <div className="flex space-x-3 w-full">

--- a/src/components/strikey/ModifierContainer.tsx
+++ b/src/components/strikey/ModifierContainer.tsx
@@ -21,7 +21,7 @@ const ModifierContainer: React.FC<ModifierContainerProps> = ({ type, items, quic
       <button className="py-1 bg-teal-500 rounded-md w-full ease-in-out duration-300 hover:scale-105" type="button" onClick={() => addModifier(type)}>{type === 'penalty' ? 'Add Penalty' : 'Add Bonus'}</button>
     </div>
     <QuickAddContainer items={items} type={type} quickAdd={quickAdd} />
-    <ul className="bg-teal-950 shadow-inner p-3 w-full grid grid-cols-2 gap-2 gap-y-2 auto-rows-max h-52" id={type === 'penalty' ? 'penaltyList' : 'bonusList'}></ul>
+    <ul className="bg-teal-950 shadow-inner p-3 w-full grid grid-cols-2 gap-2 gap-y-2 auto-rows-max h-52 no-scrollbar overflow-y-auto" id={type === 'penalty' ? 'penaltyList' : 'bonusList'}></ul>
   </div>
 );
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  @variants responsive {
+
+    /* Chrome, Safari and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+
+    .no-scrollbar {
+      -ms-overflow-style: none;
+      /* IE and Edge */
+      scrollbar-width: none;
+      /* Firefox */
+    }
+  }
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/pages/Strikey.tsx
+++ b/src/pages/Strikey.tsx
@@ -150,30 +150,49 @@ const Strikey = () => {
   const stats = ['strength', 'constitution', 'discipline', 'will', 'intelligence', 'sense'];
 
   return (
-    <div className="w-screen h-screen items-center flex justify-center flex-col space-y-6 overflow-y-auto mt-12">
-        <h1 className='text-5xl font-bold'>Strike Assistant Module</h1>
-        <div className="flex justify-between w-100 space-x-3">
+    <div className="w-screen sm:items-center flex justify-center flex-col overflow-y-auto sm:h-screen sm:space-y-6 sm:mt-12">
+        <h1 className='invisible font-bold sm:visible sm:shown sm:text-5xl'>Strike Assistant Module</h1>
+        <div className="flex w-screen flex-wrap pb-2 sm:pb-0 justify-around sm:justify-between w-100 sm:space-x-3 sm:w-auto">
           {stats.map((stat, index) => (
             <StatInput key={index} name={stat} statChange={handleStatChange} />
               ))}
         </div>
       <form id="rollhtmlForm">
-        <div className='flex space-x-5'>
+      <div className='flex flex-col sm:flex-row sm:space-x-5'>
           <ModifierContainer type='bonus' items={quickAddBonuses} quickAdd={quickAdd} addModifier={addModifier} />
           <ModifierContainer type='penalty' items={quickAddPenalties} quickAdd={quickAdd} addModifier={addModifier} />
         </div>
-          <div className='flex space-x-3 items-center mt-5'>
+          
+          {/* calculation section for small and larger screens */}
+          <div className='hidden sm:flex sm:flex-wrap space-x-3 items-center mt-5'>
             <div className="htmlForm-group rounded-md bg-teal-900 p-3">
-              <label className="" htmlFor="statSelection">Select Stat:</label>
+              <label htmlFor="statSelection">Select Stat:</label>
+              <select className='bg-inherit rounded-md border-2 border-teal-500 p-1 sm:p-2 ml-2 sm:ml-3' id="statSelection" name="statSelection" onChange={handleStatChange}>
+                {stats.map((stat, index) => (
+                  <option key={index} value={stat.toLowerCase()}>{stat.toUpperCase()}</option>
+                ))}
+              </select>
+            </div>
+          <p className='rounded-md bg-teal-900 p-2 sm:p-5'>Success: {currentThreshold} Crit: { Math.floor(currentThreshold / 4)} </p>
+            <button className="bg-teal-500 h-full sm:p-5 rounded-md ease-in-out duration-300 hover:scale-105" type="button" onClick={() => rollD100()}>ROLL</button>
+          <div className={`bg-teal-950 shadow-inner sm:p-5 grow h-full rounded-md result border-2 border-teal-700 ${resultClass}`} id="result">{result}</div>
+          </div>
+
+          {/* calculation section for below small screens */}
+          <div className='flex sm:hidden flex-wrap space-x-3 items-center justify-center'>
+            <div className="htmlForm-group rounded-md bg-teal-900 p-3">
+              <label htmlFor="statSelection">Select Stat:</label>
               <select className='bg-inherit rounded-md border-2 border-teal-500 p-2 ml-3' id="statSelection" name="statSelection" onChange={handleStatChange}>
                 {stats.map((stat, index) => (
                   <option key={index} value={stat.toLowerCase()}>{stat.toUpperCase()}</option>
                 ))}
               </select>
             </div>
-          <p className='rounded-md bg-teal-900 p-5'>Success: {currentThreshold} Crit: { Math.floor(currentThreshold / 4)} </p>
-            <button className="bg-teal-500 h-full p-5 rounded-md ease-in-out duration-300 hover:scale-105" type="button" onClick={() => rollD100()}>ROLL</button>
-          <div className={`bg-teal-950 shadow-inner p-5 grow h-full rounded-md result border-2 border-teal-700 ${resultClass}`} id="result">{result}</div>
+            <button className="bg-teal-500 h-full p-5 rounded-md ease-in-out duration-300" type="button" onClick={() => rollD100()}>ROLL</button>
+            <div className='flex py-2'>
+          <p className='rounded-md bg-teal-900 p-5 mr-2'>Success: {currentThreshold} Crit: { Math.floor(currentThreshold / 4)} </p>
+          <div className={`bg-teal-950 shadow-inner p-5 h-full rounded-md result border-2 border-teal-700 ${resultClass}`} id="result">{result}</div>
+          </div>
           </div>
         </form>
     </div>


### PR DESCRIPTION
This PR aims to make SAM usable on mobile devices. This is achieved by changing the default styling and making the previous styling apply to small and larger screens. This PR does not handle the layout of SAM for tablet sized devices.

This PR also adds the no-scrollbar class to add scroll functionality without displaying the scrollbar.

See attached screenshots for demonstration on an iphone 11 pro max sized screen:

![image](https://github.com/nodonnell98/mutagenui/assets/50716198/5473d8a7-8fc1-4e7f-bd6b-9f2cef7f7aa3)
![image](https://github.com/nodonnell98/mutagenui/assets/50716198/3d480cbe-40a1-4e69-ba42-7d9542f9ff6c)
